### PR TITLE
Don't depend on /bin/bash

### DIFF
--- a/echoz.sh
+++ b/echoz.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -euf
 thisdir="$(dirname $0)"
 pipename="${XDG_RUNTIME_DIR:-/tmp}/echoz-$$.pipe"
@@ -9,11 +9,11 @@ domain="$(echo "$jid" | cut -d'@' -f2)"
 srv="$( ( dig +short SRV "_xmpp-client._tcp.$domain" || echo "0 0 5222 $domain" ) | sort -n)"
 host="$(echo "$srv" | cut -d' ' -f4)"
 port="$(echo "$srv" | cut -d' ' -f3)"
-authstr="$(echo -ne "\0$username\0$password" | base64)"
+authstr="$(printf '\0%s\0%s' "$username" "$password" | base64)"
 rm -f "$pipename"
 mkfifo "$pipename"
 DEBUG_PATH=${DEBUG_PATH:-}
-if [[ "x$DEBUG_PATH" != "x" ]]; then
+if [ "x$DEBUG_PATH" != "x" ]; then
   debug_recv="${DEBUG_PATH}recv.xml"
   debug_sent="${DEBUG_PATH}sent.xml"
   rm -f "$debug_sent" "$debug_recv"
@@ -28,7 +28,7 @@ stdbuf -i0 -o0 \
     -connect "$host:$port" \
     -quiet \
     < "$pipename" \
-  | (echo -ne "$jid $authstr\n"; \
+  | (printf '%s %s\n' "$jid" "$authstr"; \
      stdbuf -o0 tr '>\n' '\n\001') \
   | stdbuf -o0 tee "$debug_recv" \
   | stdbuf -o0 "$thisdir/echoz.sed" \


### PR DESCRIPTION
Make `echoz.sh` work on Unix systems that don't have `/bin/bash`.