### PR TITLE
Cope with space characters in path

### DIFF
--- a/echoz.sh
+++ b/echoz.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -euf
-thisdir="$(dirname $0)"
+thisdir="$(dirname "$0")"
 pipename="${XDG_RUNTIME_DIR:-/tmp}/echoz-$$.pipe"
 jid="$1"
 password="$2"


### PR DESCRIPTION
Don't fail if the echo bot is run from a directory with space characters in the path name.